### PR TITLE
chore: add git strategy files for open-source workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- 버그에 대한 명확한 설명 -->
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+<!-- 예상 동작 -->
+
+## Actual Behavior
+<!-- 실제 동작 -->
+
+## Environment
+- OS:
+- Node.js version:
+- Rust version:
+- Codex Pulse version:
+
+## Additional Context
+<!-- 스크린샷, 로그 등 추가 정보 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for Codex Pulse
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+<!-- 어떤 문제를 해결하고 싶은지 설명 -->
+
+## Proposed Solution
+<!-- 제안하는 해결 방법 -->
+
+## Alternatives Considered
+<!-- 고려한 대안이 있다면 설명 -->
+
+## Additional Context
+<!-- 참고 자료, 스크린샷 등 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+<!-- 변경 사항 요약 -->
+
+## Changes
+-
+
+## Test Plan
+- [ ] `cargo check` 통과
+- [ ] `npm run check` 통과
+- [ ] 관련 기능 수동 확인

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: cargo check
+      - run: cargo build --release
+      - run: npm install
+      - run: npm run check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Codex Pulse
+
+Thank you for your interest in contributing to Codex Pulse!
+
+## Prerequisites
+
+- [Rust](https://rustup.rs/) (stable toolchain)
+- [Node.js](https://nodejs.org/) >= 20
+- npm
+
+## Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/<owner>/codex-pulse.git
+cd codex-pulse
+
+# Install Node dependencies
+npm install
+
+# Build the Rust backend
+cargo build --release
+
+# Run checks
+npm run check
+```
+
+## Development Workflow
+
+1. Fork the repository and create a branch from `main`:
+   - `feat/<name>` for new features
+   - `fix/<name>` for bug fixes
+   - `docs/<name>` for documentation changes
+   - `refactor/<name>` for refactoring
+2. Make your changes and commit using [Conventional Commits](#commit-convention).
+3. Ensure all checks pass: `npm run check`
+4. Open a Pull Request against `main`.
+
+## Commit Convention
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:** `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`
+
+**Scopes (optional):** `api`, `sse`, `ui`, `desktop`, `collector`, `docs`
+
+**Rules:**
+- Subject line: 70 characters max, lowercase start, no period
+- Breaking changes: add `BREAKING CHANGE:` in the commit footer
+
+**Examples:**
+```
+feat(api): add token usage endpoint
+fix(sse): reconnect on timeout
+docs(readme): add installation instructions
+```
+
+## Pull Requests
+
+- Fill out the PR template.
+- Ensure CI passes (`cargo check`, `npm run check`).
+- Keep PRs focused — one logical change per PR.
+
+## Reporting Issues
+
+Use the provided issue templates for bug reports and feature requests.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Codex Pulse Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
오픈소스 워크플로우를 위한 Git 전략 파일 추가

## Changes
- `LICENSE` — MIT 라이선스
- `CONTRIBUTING.md` — 기여 가이드 (빌드 방법, 커밋 컨벤션, PR 규칙)
- `.github/pull_request_template.md` — PR 템플릿
- `.github/ISSUE_TEMPLATE/bug_report.md` — 버그 리포트 템플릿
- `.github/ISSUE_TEMPLATE/feature_request.md` — 기능 요청 템플릿
- `.github/workflows/ci.yml` — CI 워크플로우 (cargo check + build, npm install + check)

## Test Plan
- [x] `cargo check` 통과
- [x] `npm run check` 통과
- [x] 파일 구조 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)